### PR TITLE
Fix: public API toggle silently fails to save on auth/CSRF error

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4591,21 +4591,35 @@ function applyDcLang() {
 let _publicApiState = false;
 
 function togglePublicApi() {
-  _publicApiState = !_publicApiState;
-  const tog = document.getElementById('tog-public-api');
-  const lab = document.getElementById('lab-public-api');
-  if (tog) tog.className = 'toggle' + (_publicApiState ? ' on' : '');
-  if (lab) lab.textContent = t(_publicApiState ? 'on' : 'off');
-  MSLog.info('togglePublicApi →', _publicApiState);
+  const next = !_publicApiState;
+  MSLog.info('togglePublicApi →', next);
   fetch(BASE + '/api/config', {method:'POST', headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({public_api_state: _publicApiState})
-  }).then(r => r.json()).then(d => {
-    if (d.ok) showActionMessage(
-      currentLang === 'de'
-        ? (_publicApiState ? '✓ /api/state ist jetzt öffentlich zugänglich (kein Login)' : '✓ /api/state erfordert jetzt Login')
-        : (_publicApiState ? '✓ /api/state is now publicly accessible (no login)' : '✓ /api/state now requires login'),
-      _publicApiState ? 'warning' : 'success', 5000);
-  }).catch(e => MSLog.error('togglePublicApi save failed', e));
+    body: JSON.stringify({public_api_state: next})
+  }).then(async r => {
+    const d = await r.json().catch(() => ({}));
+    if (r.ok && d.ok) {
+      _publicApiState = next;
+      const tog = document.getElementById('tog-public-api');
+      const lab = document.getElementById('lab-public-api');
+      if (tog) tog.className = 'toggle' + (_publicApiState ? ' on' : '');
+      if (lab) lab.textContent = t(_publicApiState ? 'on' : 'off');
+      showActionMessage(
+        currentLang === 'de'
+          ? (_publicApiState ? '✓ /api/state ist jetzt öffentlich zugänglich (kein Login)' : '✓ /api/state erfordert jetzt Login')
+          : (_publicApiState ? '✓ /api/state is now publicly accessible (no login)' : '✓ /api/state now requires login'),
+        _publicApiState ? 'warning' : 'success', 5000);
+    } else {
+      MSLog.error('togglePublicApi save failed', d.error || r.status);
+      showActionMessage(
+        currentLang === 'de'
+          ? 'Speichern fehlgeschlagen — bitte neu einloggen und erneut versuchen'
+          : 'Save failed — please log in again and retry',
+        'error', 5000);
+    }
+  }).catch(e => {
+    MSLog.error('togglePublicApi save failed', e);
+    showActionMessage(currentLang === 'de' ? 'Speichern fehlgeschlagen' : 'Save failed', 'error', 5000);
+  });
 }
 
 async function exportConfig() {


### PR DESCRIPTION
## Summary
- `togglePublicApi()` updated the switch UI optimistically before the save request resolved, and only checked the JSON body's `ok` field to show a *success* toast — a non-2xx response (expired session → 401, stale CSRF → 403) left the switch showing "on" with no error shown, while nothing was actually persisted server-side.
- Confirmed via direct testing against `/api/config` that persistence itself was already correct once a request succeeds (survives disk write, restart, etc.) — this was purely a client-side silent-failure bug.
- Now the UI only updates after a confirmed `2xx` + `{ok:true}` response; a failed save surfaces a visible error toast instead of failing silently.
- Particularly relevant here since this setting controls whether `/api/state` is exposed without authentication — a silently-wrong toggle is a bigger problem on a security-relevant control than a cosmetic one.

## Test plan
- [x] `node --check` on the extracted script block — no syntax errors
- [x] Built and ran the branch via the repo's own `Dockerfile` in an isolated container
- [x] Simulated the success path (valid session + correct CSRF) — `{"ok":true}`, `public_api_state` correctly flips and persists to disk
- [x] Simulated the failure path (valid session + stale/wrong CSRF, same response shape as an expired session) — `{"ok":false,"error":"CSRF validation failed"}`, and disk state correctly stays unchanged rather than silently claiming success